### PR TITLE
Update language references from 'js' to 'javaScript'

### DIFF
--- a/src/components/Workspace/Playground/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/Workspace/Playground/LanguageSelector/LanguageSelector.tsx
@@ -12,7 +12,7 @@ const LanguageSelect: React.FC<LanguageSelectProps> = ({ settings, setSettings }
   const handleChange = (value: string) => {
     setSettings((prev) => ({
       ...prev,
-      language: value as 'js' | 'python' | 'cpp',
+      language: value as 'javaScript' | 'python' | 'cpp',
     }));
   };
 
@@ -36,7 +36,7 @@ const LanguageSelect: React.FC<LanguageSelectProps> = ({ settings, setSettings }
           className="bg-dark-layer-1 text-white rounded shadow-lg border border-dark-divider-border-2 z-50"
         >
           <Select.Viewport className="p-1 bg-dark-layer-1">
-            {['js', 'python', 'cpp'].map((lang) => (
+            {['javaScript', 'python', 'cpp'].map((lang) => (
               <Select.Item
                 key={lang}
                 value={lang}

--- a/src/components/Workspace/Playground/Playground.tsx
+++ b/src/components/Workspace/Playground/Playground.tsx
@@ -25,12 +25,12 @@ export interface ISettings {
     fontSize: string;
     settingModalIsOpen: boolean;
     dropdownIsOpen: boolean;
-    language: 'js' | 'python' | 'cpp';
+    language: 'javaScript' | 'python' | 'cpp';
 };
 
 const Playground: React.FC<PlaygroundProps> = ({ problem, setSuccess, setSolved }) => {
-    let [userCode, setUserCode] = useState<string>(problem.starterCode['js']);
-    const [storedLanguage, setStoredLanguage] = useLocalStorage("lcc-language", "js");
+    let [userCode, setUserCode] = useState<string>(problem.starterCode['javaScript']);
+    const [storedLanguage, setStoredLanguage] = useLocalStorage("lcc-language", "javaScript");
     const [activeTestCaseId, setActiveTestCaseId] = useState<number>(0);
     const [fontSize, setFontSize] = useLocalStorage("lcc-fontSize", "16px");
     const [settings, setSettings] = useState<ISettings>({
@@ -49,7 +49,7 @@ const Playground: React.FC<PlaygroundProps> = ({ problem, setSuccess, setSolved 
 
     const getLanguageExtension = () => {
         switch (settings.language) {
-            case 'js': return javascript();
+            case 'javaScript': return javascript();
             case 'python': return python();
             case 'cpp': return cpp();
             default: return javascript();

--- a/src/pages/api/run.ts
+++ b/src/pages/api/run.ts
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const languageMap: Record<string, string> = {
-    js: 'js',
+    javaScript: 'js',
     python: 'python',
     cpp: 'cpp',
   };

--- a/src/utils/problems/a-cappella-recording.ts
+++ b/src/utils/problems/a-cappella-recording.ts
@@ -24,7 +24,7 @@ int minRecordings(int n, int d, vector<int>& pitches) {
 }`;
 
 const languageMap: Record<Language, string> = {
-  js: starterCodeACappellaRecordingJS,
+  javaScript: starterCodeACappellaRecordingJS,
   python: starterCodeACappellaRecordingPython,
   cpp: starterCodeACappellaRecordingCPP,
 };

--- a/src/utils/problems/abc-string.ts
+++ b/src/utils/problems/abc-string.ts
@@ -22,7 +22,7 @@ int minBeautifulSubsequences(string s) {
 }`;
 
 const languageMap: Record<Language, string> = {
-  js: starterCodeABCStringJS,
+  javaScript: starterCodeABCStringJS,
   python: starterCodeABCStringPython,
   cpp: starterCodeABCStringCPP,
 };

--- a/src/utils/types/problem.ts
+++ b/src/utils/types/problem.ts
@@ -32,4 +32,4 @@ export type DBProblem = {
 	link?: string;
 };
 
-export type Language = 'js' | 'python' | 'cpp';
+export type Language = 'javaScript' | 'python' | 'cpp';


### PR DESCRIPTION
Change all instances of 'js' to 'javaScript' in components and utilities to ensure consistency in language references.